### PR TITLE
Implement session uploading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.0]
+
+- Added `oneDrive.items.uploadSession` function for uploading large files
+
 ## [0.2.1]
 
 - Resolved package vulnerabilities

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm install onedrive-api
   - [listChildren](#itemslistchildren)
   - [update](#itemsupdate)
   - [uploadSimple](#itemsuploadsimple)
+  - [uploadSession](#itemsuploadsession)
 
 # Examples
 
@@ -31,9 +32,9 @@ npm install onedrive-api
 ```javascript
 var oneDriveAPI = require('onedrive-api');
 ```
-  
+
 Since version 0.2.0 this npm module supports accessing shared files. Simply provide the parameter shared as true along
-with the user, who originally owns the files. Keep in mind, that in order to access the files the access token requires 
+with the user, who originally owns the files. Keep in mind, that in order to access the files the access token requires
 certain scopes (e.g. files.read.all). See the following snippet:
 
 ```javascript
@@ -43,19 +44,19 @@ oneDriveAPI.items.listChildren({
     shared: true,
     user: 'dkatavic'
   }).then((childrens) => {
-  // list all children of dkatavics root directory  
+  // list all children of dkatavics root directory
   //
   // console.log(childrens);
   // returns body of https://dev.onedrive.com/items/list.htm#response
   })
 ```
 
-  
+
 ### items.createFolder
 
 Create Folder
 
-**Returns**: <code>Object</code> - folder object  
+**Returns**: <code>Object</code> - folder object
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -82,7 +83,7 @@ oneDriveAPI.items.createFolder({
 
 Delete item (file or folder)
 
-**Returns**: <code>undefined</code> - (204 No content)  
+**Returns**: <code>undefined</code> - (204 No content)
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -105,14 +106,14 @@ oneDriveAPI.items.delete({
 
 Download item content
 
-**Returns**: <code>Object</code> - Readable stream with item's content  
+**Returns**: <code>Object</code> - Readable stream with item's content
 
 
 | Param | Type | Description |
 | --- | --- | --- |
 | params | <code>Object</code> |  |
 | params.accessToken | <code>String</code> | OneDrive access token |
-| params.itemId | <code>String</code> | item id |  
+| params.itemId | <code>String</code> | item id |
 | params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
 | params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
 
@@ -128,7 +129,7 @@ fileStream.pipe(SomeWritableStream);
 
 Get items metadata (file or folder)
 
-**Returns**: <code>Object</code> - Item's metadata  
+**Returns**: <code>Object</code> - Item's metadata
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -153,7 +154,7 @@ oneDriveAPI.items.getMetadata({
 
 List childrens
 
-**Returns**: <code>Array</code> - object of children items  
+**Returns**: <code>Array</code> - object of children items
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -178,7 +179,7 @@ oneDriveAPI.items.listChildren({
 
 Update item metadata
 
-**Returns**: <code>Object</code> - Item object  
+**Returns**: <code>Object</code> - Item object
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -207,7 +208,7 @@ oneDriveAPI.items.update({
 
 Create file with simple upload
 
-**Returns**: <code>Object</code> - Item  
+**Returns**: <code>Object</code> - Item
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -216,7 +217,7 @@ Create file with simple upload
 | params.filename | <code>String</code> |  | File name |
 | [params.parentId] | <code>String</code> | <code>root</code> | Parent id |
 | [params.parentPath] | <code>String</code> |  | Parent path (if parentPath is defined, than parentId is ignored) |
-| params.readableStream | <code>Object</code> |  | Readable Stream with file's content | 
+| params.readableStream | <code>Object</code> |  | Readable Stream with file's content |
 | params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
 | params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
 
@@ -229,6 +230,67 @@ oneDriveAPI.items.uploadSimple({
 }).then((item) => {
 // console.log(item);
 // returns body of https://dev.onedrive.com/items/upload_put.htm#response
+})
+```
+
+### items.uploadSimple
+
+Create file with simple upload
+
+**Returns**: <code>Object</code> - Item
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| params | <code>Object</code> |  |  |
+| params.accessToken | <code>String</code> |  | OneDrive access token |
+| params.filename | <code>String</code> |  | File name |
+| [params.parentId] | <code>String</code> | <code>root</code> | Parent id |
+| [params.parentPath] | <code>String</code> |  | Parent path (if parentPath is defined, than parentId is ignored) |
+| params.readableStream | <code>Object</code> |  | Readable Stream with file's content |
+| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
+| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+
+
+```javascript
+oneDriveAPI.items.uploadSimple({
+  accessToken: accessToken,
+  filename: filename,
+  readableStream: readableStream
+}).then((item) => {
+// console.log(item);
+// returns body of https://dev.onedrive.com/items/upload_put.htm#response
+})
+```
+
+### items.uploadSession
+
+Create file with session upload. Use this for the files over 4MB. This is a synchronous wrapper around asynchronous method, which means that on the failed upload you can't resume the upload but need to retry the implementation. I am accepting PRs for asynchronous implementation
+
+**Returns**: <code>Object</code> - Item
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| params | <code>Object</code> |  |  |
+| params.accessToken | <code>String</code> |  | OneDrive access token |
+| params.filename | <code>String</code> |  | File name |
+| params.fileSize | <code>Number</code> |  | Size of the file |
+| [params.parentId] | <code>String</code> | <code>root</code> | Parent id |
+| [params.parentPath] | <code>String</code> |  | Parent path (if parentPath is defined, than parentId is ignored) |
+| params.readableStream | <code>Object</code> |  | Readable Stream with file's content |
+| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
+| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+| [params.chunksToUpload] | <code>Number</code> | <code>20</code> | Chunks to upload per request. More chunks per request requires more RAM |
+
+
+```javascript
+oneDriveAPI.items.uploadSession({
+  accessToken: accessToken,
+  filename: filename,
+  fileSize: fileSize,
+  readableStream: readableStream
+}).then((item) => {
+// console.log(item);
+// returns body of https://docs.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#http-response
 })
 ```
 

--- a/lib/items/index.js
+++ b/lib/items/index.js
@@ -6,6 +6,7 @@ var listChildren = require('./listChildren'),
     update = require('./update'),
     getMetadata = require('./getMetadata'),
     uploadSimple = require('./uploadSimple'),
+    uploadSession = require('./uploadSession'),
     _delete = require('./delete');
 
 module.exports = {
@@ -13,6 +14,7 @@ module.exports = {
   listChildren: listChildren,
   createFolder: createFolder,
   uploadSimple: uploadSimple,
+  uploadSession: uploadSession,
   update: update,
   getMetadata: getMetadata,
   download: download,

--- a/lib/items/uploadSession.js
+++ b/lib/items/uploadSession.js
@@ -52,9 +52,12 @@ function uploadSession(params) {
       uri = appConfig.apiUrl + userPath + 'drive/' + params.parentId + ':/' + params.filename + ':/createUploadSession';
     }
 
+    // total uploaded bytes
     var uploadedBytes = 0;
+    // size of the chunks that are going to be uploaded
     var chunksToUploadSize = 0;
-    var chunksToUpload = [];
+    // chunks we've accumulated in memory that we're going to upload
+    var chunks = [];
 
     var urlResponse;
 
@@ -77,14 +80,14 @@ function uploadSession(params) {
         return reject(urlResponse.body);
       }
       params.readableStream.on("data", function (chunk) {
-        chunksToUpload.push(chunk);
+        chunks.push(chunk);
         chunksToUploadSize += chunk.length;
 
-        // upload only if we've 20 chunks in memory OR we're uploading the final chunk
-        if (chunksToUpload.length === params.chunksToUpload || chunksToUploadSize + uploadedBytes === params.fileSize) {
+        // upload only if we've specified number of chunks in memory OR we're uploading the final chunk
+        if (chunks.length === params.chunksToUpload || chunksToUploadSize + uploadedBytes === params.fileSize) {
           params.readableStream.pause();
           // make buffer from the chunks
-          var data = Buffer.concat(chunksToUpload, chunksToUploadSize);
+          var payload = Buffer.concat(chunks, chunksToUploadSize);
           var uploadResponse
           request({
             method: "PUT",
@@ -93,7 +96,7 @@ function uploadSession(params) {
               "Content-Length": chunksToUploadSize,
               "Content-Range": 'bytes ' + uploadedBytes + '-' + (uploadedBytes + chunksToUploadSize - 1) + '/' + params.fileSize
             },
-            body: data,
+            body: payload,
             resolveWithFullResponse: true
           }).then(function (_uploadResponse) {
             uploadResponse = _uploadResponse
@@ -101,9 +104,15 @@ function uploadSession(params) {
               return reject(uploadResponse.body);
             }
 
-            // reset for next chunks
+            // update uploaded bytes
             uploadedBytes += chunksToUploadSize;
-            chunksToUpload = [];
+            /* TODO: 
+            ** emit an event here, that emits the value of uploadedBytes,
+            ** this can be listened to by the caller to check the current upload progress 
+            */
+
+            // reset for next chunks
+            chunks = [];
             chunksToUploadSize = 0;
 
             if (

--- a/lib/items/uploadSession.js
+++ b/lib/items/uploadSession.js
@@ -1,7 +1,7 @@
 // uploadSession.js
-const request = require('request-promise');
-const path = require('path');
-const userPathGenerator = require('../helpers/pathHelper');
+var request = require("request-promise");
+var path = require("path");
+var userPathGenerator = require("../helpers/pathHelper");
 
 /**
  * @function uploadSession
@@ -11,6 +11,7 @@ const userPathGenerator = require('../helpers/pathHelper');
  * @param {String} params.accessToken OneDrive access token
  * @param {String} params.filename File name
  * @param {String} [params.parentId=root] Parent id
+ * @param {String} [params.parentPath] Parent id
  * @param {Object} params.readableStream Readable Stream with file's content
  * @param {Number} params.fileSize Size of file
  * @param {Number} [params.chunksToUpload=20] Number of chunks to upload at a time
@@ -20,93 +21,104 @@ const userPathGenerator = require('../helpers/pathHelper');
 
 function uploadSession(params) {
   if (!params.accessToken) {
-    throw new Error('Missing params.accessToken');
+    throw new Error("Missing params.accessToken");
   }
 
   if (!params.filename) {
-    throw new Error('Missing params.filename');
+    throw new Error("Missing params.filename");
   }
 
   if (!params.readableStream) {
-    throw new Error('Missing params.readableStream');
+    throw new Error("Missing params.readableStream");
   }
 
   if (!params.fileSize) {
-    throw new Error('Missing params.fileSize');
+    throw new Error("Missing params.fileSize");
   }
 
-  return new Promise((async (resolve, reject) => {
+  return new Promise(function (resolve, reject) {
     params.parentId = params.parentId === undefined ? 'root' : params.parentId;
-    const userPath = userPathGenerator(params);
+    var userPath = userPathGenerator(params);
 
     params.chunksToUpload = params.chunksToUpload === undefined ? 20 : params.chunksToUpload;
 
-    let uri = `${appConfig.apiUrl + userPath}drive/${params.parentId}:/${params.filename}:/createUploadSession`;
-
-    if (params.parentPath !== undefined && typeof (params.parentPath) === 'string') {
-      uri = `${appConfig.apiUrl + userPath}drive/root:/${path.join(params.parentPath, params.filename)}:/createUploadSession`;
+    var uri
+    if (params.parentPath !== undefined && typeof params.parentPath === "string") {
+      uri = appConfig.apiUrl + userPath + ' drive/root:/' + params.parentPath + ':/createUploadSession';
+    } else if (params.parentId) {
+      uri = appConfig.apiUrl + userPath + 'drive/items/' + params.parentId + ':/' + params.filename + ':/createUploadSession';
+    } else {
+      params.parentId = "root";
+      uri = appConfig.apiUrl + userPath + 'drive/' + params.parentId + ':/' + params.filename + ':/createUploadSession';
     }
 
-    let uploadedBytes = 0;
-    let chunksToUploadSize = 0;
-    let chunksToUpload = [];
+    var uploadedBytes = 0;
+    var chunksToUploadSize = 0;
+    var chunksToUpload = [];
 
-    const urlResponse = await request({
-      method: 'POST',
+    var urlResponse;
+
+    request({
+      method: "POST",
       uri,
       headers: {
-        Authorization: `Bearer ${params.accessToken}`,
+        Authorization: 'Bearer ' + params.accessToken
       },
       body: {
-        '@microsoft.graph.conflictBehavior': 'rename',
-        fileSystemInfo: { '@odata.type': 'microsoft.graph.fileSystemInfo' },
-        name: params.filename,
+        "@microsoft.graph.conflictBehavior": "rename",
+        fileSystemInfo: { "@odata.type": "microsoft.graph.fileSystemInfo" },
+        name: params.filename
       },
       resolveWithFullResponse: true,
-      json: true,
-    }).catch(e => {return reject(e)});
-
-    if (urlResponse.statusCode >= 400) {
-      return reject(urlResponse.body);
-    }
-
-    params.readableStream.on('data', async (chunk) => {
-      chunksToUpload.push(chunk);
-      chunksToUploadSize += chunk.length;
-
-      // upload only if we've 20 chunks in memory OR we're uploading the final chunk
-      if (chunksToUpload.length === params.chunksToUpload || chunksToUploadSize + uploadedBytes === params.fileSize) {
-        params.readableStream.pause();
-        // make buffer from the chunks
-        const data = Buffer.concat(chunksToUpload, chunksToUploadSize);
-
-        const uploadResponse = await request({
-          method: 'PUT',
-          uri: urlResponse.body.uploadUrl,
-          headers: {
-            'Content-Length': chunksToUploadSize,
-            'Content-Range': `bytes ${uploadedBytes}-${(uploadedBytes + chunksToUploadSize) - 1}/${params.fileSize}`,
-          },
-          body: data,
-          resolveWithFullResponse: true,
-        }).catch(e => {return reject(e)});
-
-        if (uploadResponse.statusCode >= 400) {
-          return reject(uploadResponse.body);
-        }
-
-        // reset for next chunks
-        uploadedBytes += chunksToUploadSize;
-        chunksToUpload = [];
-        chunksToUploadSize = 0;
-
-        if (uploadResponse.statusCode === 201 || uploadResponse.statusCode === 203 || uploadResponse.statusCode === 200) {
-          resolve(JSON.parse(uploadResponse.body));
-        }
-        params.readableStream.resume();
+      json: true
+    }).then(function (_urlResponse) {
+      urlResponse = _urlResponse
+      if (urlResponse.statusCode >= 400) {
+        return reject(urlResponse.body);
       }
-    });
-  }));
+      params.readableStream.on("data", function (chunk) {
+        chunksToUpload.push(chunk);
+        chunksToUploadSize += chunk.length;
+
+        // upload only if we've 20 chunks in memory OR we're uploading the final chunk
+        if (chunksToUpload.length === params.chunksToUpload || chunksToUploadSize + uploadedBytes === params.fileSize) {
+          params.readableStream.pause();
+          // make buffer from the chunks
+          var data = Buffer.concat(chunksToUpload, chunksToUploadSize);
+          var uploadResponse
+          request({
+            method: "PUT",
+            uri: urlResponse.body.uploadUrl,
+            headers: {
+              "Content-Length": chunksToUploadSize,
+              "Content-Range": 'bytes ' + uploadedBytes + '-' + (uploadedBytes + chunksToUploadSize - 1) + '/' + params.fileSize
+            },
+            body: data,
+            resolveWithFullResponse: true
+          }).then(function (_uploadResponse) {
+            uploadResponse = _uploadResponse
+            if (uploadResponse.statusCode >= 400) {
+              return reject(uploadResponse.body);
+            }
+
+            // reset for next chunks
+            uploadedBytes += chunksToUploadSize;
+            chunksToUpload = [];
+            chunksToUploadSize = 0;
+
+            if (
+              uploadResponse.statusCode === 201 ||
+              uploadResponse.statusCode === 203 ||
+              uploadResponse.statusCode === 200
+            ) {
+              resolve(JSON.parse(uploadResponse.body));
+            }
+            params.readableStream.resume();
+          }).catch(reject)
+        }
+      });
+    })
+  });
 }
 
 module.exports = uploadSession;

--- a/lib/items/uploadSession.js
+++ b/lib/items/uploadSession.js
@@ -1,0 +1,112 @@
+// uploadSession.js
+const request = require('request-promise');
+const path = require('path');
+const userPathGenerator = require('../helpers/pathHelper');
+
+/**
+ * @function uploadSession
+ * @description Create file with session upload
+ *
+ * @param {Object} params
+ * @param {String} params.accessToken OneDrive access token
+ * @param {String} params.filename File name
+ * @param {String} [params.parentId=root] Parent id
+ * @param {Object} params.readableStream Readable Stream with file's content
+ * @param {Number} params.fileSize Size of file
+ * @param {Number} [params.chunksToUpload=20] Number of chunks to upload at a time
+ *
+ * @return {Object} Item
+ */
+
+function uploadSession(params) {
+  if (!params.accessToken) {
+    throw new Error('Missing params.accessToken');
+  }
+
+  if (!params.filename) {
+    throw new Error('Missing params.filename');
+  }
+
+  if (!params.readableStream) {
+    throw new Error('Missing params.readableStream');
+  }
+
+  if (!params.fileSize) {
+    throw new Error('Missing params.fileSize');
+  }
+
+  return new Promise((async (resolve, reject) => {
+    params.parentId = params.parentId === undefined ? 'root' : params.parentId;
+    const userPath = userPathGenerator(params);
+
+    params.chunksToUpload = params.chunksToUpload === undefined ? 20 : params.chunksToUpload;
+
+    let uri = `${appConfig.apiUrl + userPath}drive/${params.parentId}:/${params.filename}:/createUploadSession`;
+
+    if (params.parentPath !== undefined && typeof (params.parentPath) === 'string') {
+      uri = `${appConfig.apiUrl + userPath}drive/root:/${path.join(params.parentPath, params.filename)}:/createUploadSession`;
+    }
+
+    let uploadedBytes = 0;
+    let chunksToUploadSize = 0;
+    let chunksToUpload = [];
+
+    const urlResponse = await request({
+      method: 'POST',
+      uri,
+      headers: {
+        Authorization: `Bearer ${params.accessToken}`,
+      },
+      body: {
+        '@microsoft.graph.conflictBehavior': 'rename',
+        fileSystemInfo: { '@odata.type': 'microsoft.graph.fileSystemInfo' },
+        name: params.filename,
+      },
+      resolveWithFullResponse: true,
+      json: true,
+    }).catch(e => {return reject(e)});
+
+    if (urlResponse.statusCode >= 400) {
+      return reject(urlResponse.body);
+    }
+
+    params.readableStream.on('data', async (chunk) => {
+      chunksToUpload.push(chunk);
+      chunksToUploadSize += chunk.length;
+
+      // upload only if we've 20 chunks in memory OR we're uploading the final chunk
+      if (chunksToUpload.length === params.chunksToUpload || chunksToUploadSize + uploadedBytes === params.fileSize) {
+        params.readableStream.pause();
+        // make buffer from the chunks
+        const data = Buffer.concat(chunksToUpload, chunksToUploadSize);
+
+        const uploadResponse = await request({
+          method: 'PUT',
+          uri: urlResponse.body.uploadUrl,
+          headers: {
+            'Content-Length': chunksToUploadSize,
+            'Content-Range': `bytes ${uploadedBytes}-${(uploadedBytes + chunksToUploadSize) - 1}/${params.fileSize}`,
+          },
+          body: data,
+          resolveWithFullResponse: true,
+        }).catch(e => {return reject(e)});
+
+        if (uploadResponse.statusCode >= 400) {
+          return reject(uploadResponse.body);
+        }
+
+        // reset for next chunks
+        uploadedBytes += chunksToUploadSize;
+        chunksToUpload = [];
+        chunksToUploadSize = 0;
+
+        if (uploadResponse.statusCode === 201 || uploadResponse.statusCode === 203 || uploadResponse.statusCode === 200) {
+          resolve(JSON.parse(uploadResponse.body));
+        }
+        params.readableStream.resume();
+      }
+    });
+  }));
+}
+
+module.exports = uploadSession;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "onedrive-api",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -328,6 +328,12 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -456,6 +462,12 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
@@ -470,6 +482,21 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "request": {
       "version": "2.88.0",
@@ -540,6 +567,25 @@
       "integrity": "sha1-z83oJ5n6YvMDQpqqeTNu6INDMv4=",
       "dev": true
     },
+    "string-to-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",
+      "integrity": "sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "supports-color": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -591,6 +637,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "uuid": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onedrive-api",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "OneDrive module for communicating with oneDrive API. Built using functional programming pattern",
   "main": "lib/index.js",
   "scripts": {
@@ -31,6 +31,7 @@
     "faker": "^3.1.0",
     "install": "0.6.1",
     "mocha": "^5.2.0",
-    "string-stream": "0.0.7"
+    "string-stream": "0.0.7",
+    "string-to-stream": "^1.1.1"
   }
 }

--- a/test/e2e/items/uploadSession.test.js
+++ b/test/e2e/items/uploadSession.test.js
@@ -1,0 +1,162 @@
+// uploadSimple.test.js
+
+const faker = require("faker");
+const stringStream = require("string-to-stream");
+
+describe("uploadSession", function () {
+  describe("Should upload Session 1kB file using Stream in root directory", function () {
+    var createdFile
+
+    it("Should upload Session 1kB file using Stream in root directory", function (done) {
+      const filename = "test-uploadSession-" + faker.random.word();
+      // 1Kb
+      const fileContent = 'a'.repeat(1 * 1024)
+      const readableStream = stringStream(fileContent);
+
+      oneDrive.items.uploadSession({
+        accessToken: accessToken,
+        filename: filename,
+        readableStream: readableStream,
+        fileSize: fileContent.length
+      }).then(function (item) {
+        expect(item.id).to.be.a('String');
+        expect(item.name).to.be.a('String');
+        expect(item.size).to.be.a('Number');
+        expect(item.size).to.be.at.least(1);
+        expect(item.id).to.be.a('String');
+        createdFile = item;
+        done();
+      }).catch((err) => {
+        console.error('Error Handled')
+        console.error(err)
+        errorHandler(done)
+      }
+      );
+
+    });
+
+    after(function (done) {
+
+      oneDrive.items.delete({
+        accessToken: accessToken,
+        itemId: createdFile.id
+      }).then(function (_folder) {
+        done();
+      }).catch(errorHandler(done));
+
+    });
+
+  })
+
+  describe("Should upload Session 10MB file using Stream", function () {
+    var createdFile
+
+    it("Should upload Session 10MB file using Stream", function (done) {
+      const filename = "test-uploadSession-" + faker.random.word();
+      // 10MB
+      const fs = require("fs");
+      const path = require("path");
+      const exampleFilePath = path.join(__dirname, "../../example-data//10MB_file.txt");
+      const readableStream = fs.createReadStream(exampleFilePath);
+      const fsStat = fs.statSync(exampleFilePath);
+      oneDrive.items
+        .uploadSession({
+          accessToken: accessToken,
+          filename: filename,
+          readableStream: readableStream,
+          fileSize: fsStat.size
+        })
+        .then(function (item) {
+          expect(item.id).to.be.a("String");
+          expect(item.name).to.be.a("String");
+          expect(item.size).to.be.a("Number");
+          expect(item.size).to.be.equal(fsStat.size);
+          expect(item.id).to.be.a("String");
+          createdFile = item;
+          done();
+        })
+        .catch(err => {
+          errorHandler(done);
+        });
+    });
+    after(function (done) {
+
+      oneDrive.items.delete({
+        accessToken: accessToken,
+        itemId: createdFile.id
+      }).then(function (_folder) {
+        done();
+      }).catch(errorHandler(done));
+
+    });
+  })
+
+  describe("Should upload Session 1kb file inside a folder using parentId", function () {
+
+    var filename, readableStream, fileContent, folderName, createdFolder;
+
+    before(function (done) {
+      filename = "test-uploadSession-" + faker.random.word();
+      fileContent = "a".repeat(1 * 1024);
+      readableStream = new stringStream(fileContent);
+      folderName = "test-uploadSessionFolder-" + faker.random.word();
+
+      oneDrive.items
+        .createFolder({
+          accessToken: accessToken,
+          rootItemId: "root",
+          name: folderName
+        })
+        .then(function (folder) {
+          createdFolder = folder;
+          done();
+        })
+        .catch(done);
+    });
+
+    it("Should upload Session 1kb file inside a folder using parentId", function (done) {
+      filename = "test-uploadSession-" + faker.random.word();
+      // 1Kb
+
+      oneDrive.items
+        .uploadSession({
+          accessToken: accessToken,
+          filename: filename,
+          readableStream: readableStream,
+          fileSize: fileContent.length,
+          parentId: createdFolder.id
+        })
+        .then(function (item) {
+          expect(item.id).to.be.a("String");
+          expect(item.name).to.be.a("String");
+          expect(item.size).to.be.a("Number");
+          expect(item.size).to.be.at.least(1);
+          expect(item.id).to.be.a("String");
+          createdFile = item;
+          done();
+        })
+        .catch(err => {
+          console.error(err);
+          errorHandler(done);
+        });
+    });
+
+    after(function (done) {
+
+      oneDrive.items.delete({
+        accessToken: accessToken,
+        itemId: createdFile.id
+      }).then(function () {
+        return oneDrive.items.delete({
+          accessToken: accessToken,
+          itemId: createdFolder.id
+        });
+      }).then(function (_folder) {
+        done();
+      }).catch(errorHandler(done));
+
+    });
+
+  })
+
+});


### PR DESCRIPTION
I've implemented session uploading with readstream (just like uploadSimple). The size of the file must be provided because Onedrive doesn't allow uploads of unknown sizes. What I'm doing is reading the stream chunk by chunk and accumulating them in an array. Once we have 20 chunks (can be changed to allow much more data to be uploaded albeit at the cost of RAM), we load them into a buffer and send it off. 
I haven't been able to figure out how to handle uploads inside a specific folder though. I went over the original documentation but I can't seem to figure it out. So only uploads at root are working.
As for the tests, I don't know how to configure them (I'm not very experienced in node).