### PR TITLE
Adding feature: Partial range download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.5.0]
+
+- Added new api: `partialDownload()`.
+- Fixing `README.md`: Change `share` and `user` in `params` => `drive` and `driveId` according to `v0.4.0`
+
 ## [0.4.0]
 
 - Added progress callback to uploadSession

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install onedrive-api
   - [createFolder](#itemscreatefolder)
   - [delete](#itemsdelete)
   - [download](#itemsdownload)
+  - [partialDownload](#itemspartialdownload)
   - [getMetadata](#itemsgetmetadata)
   - [listChildren](#itemslistchildren)
   - [update](#itemsupdate)
@@ -39,7 +40,7 @@ var oneDriveAPI = require('onedrive-api');
 oneDriveAPI.items.listChildren({
     accessToken: accessToken,
     itemId: 'root',
-    drive: 'me' // 'me' | 'user' | 'drive' | 'group' | 'site'
+    drive: 'me', // 'me' | 'user' | 'drive' | 'group' | 'site'
     driveId: '' // BLANK | {user_id} | {drive_id} | {group_id} | {sharepoint_site_id}
   }).then((childrens) => {
   // list all children of given root directory
@@ -62,8 +63,8 @@ Create Folder
 | params.accessToken | <code>String</code> |  | OneDrive access token |
 | [params.rootItemId] | <code>String</code> | <code>root</code> | Item id |
 | params.name | <code>String</code> |  | New folder name |
-| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
-| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
 ```javascript
@@ -83,13 +84,13 @@ Delete item (file or folder)
 
 **Returns**: <code>undefined</code> - (204 No content)
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
 | params | <code>Object</code> |  |
-| params.accessToken | <code>String</code> | OneDrive access token |
-| params.itemId | <code>String</code> | Item id |
-| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
-| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+| params.accessToken | <code>String</code> |  | OneDrive access token |
+| params.itemId | <code>String</code> |  | Item id |
+| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
 ```javascript
@@ -107,18 +108,52 @@ Download item content
 **Returns**: <code>Object</code> - Readable stream with item's content
 
 
-| Param | Type | Description |
-| --- | --- | --- |
-| params | <code>Object</code> |  |
-| params.accessToken | <code>String</code> | OneDrive access token |
-| params.itemId | <code>String</code> | item id |
-| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
-| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+| Param | Type |  Default | Description |
+| --- | --- | --- | --- |
+| params | <code>Object</code> |  |  |
+| params.accessToken | <code>String</code> | | OneDrive access token |
+| params.itemId | <code>String</code> |  | item id |
+| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 ```javascript
 var fileStream = oneDriveAPI.items.download({
   accessToken: accessToken,
   itemId: createdFolder.id
+});
+fileStream.pipe(SomeWritableStream);
+```
+
+### items.partialDownload
+
+Download item content partially. You must either provide `graphDownloadURL` or the `itemId` to download the file. 
+
+If only the `itemId` is provided, the function will try to get the download URL for you with additional `getMetadata()` function call.
+
+**Returns**: <code>Object</code> - Readable stream with item's content
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| params | <code>Object</code> | |  |
+| params.accessToken | <code>String</code> | | OneDrive access token |
+| params.graphDownloadURL | <code>String</code> | | `@microsoft.graph.downloadUrl` of the item |
+| params.itemId | <code>String</code> |  | item id. This parameter will be skipped if `graphDownloadURL` is provided. |
+| params.bytesFrom | <code>Number</code> | `0` | Starting download byte. |
+| params.bytesTo | <code>Number</code> | | Ending byte to download. Must be set |
+| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
+
+```javascript
+var fileStream = oneDriveAPI.items.partialDownload({
+  accessToken: accessToken,
+  bytesFrom: 0, // start byte
+  bytesTo: 1034, // to byte
+  graphDownloadURL: createdItem['@microsoft.graph.downloadUrl'],
+  // optional params
+  itemId: createdItem.id, // only be used when `graphDownloadURL` is NOT provided
+  drive: 'me', // only be used when only `itemId` is provided
+  driveId: 'me' // only be required when `drive` is provided
 });
 fileStream.pipe(SomeWritableStream);
 ```
@@ -180,13 +215,13 @@ Get items metadata (file or folder)
 
 **Returns**: <code>Object</code> - Item's metadata
 
-| Param | Type | Description |
-| --- | --- | --- |
-| params | <code>Object</code> |  |
-| params.accessToken | <code>String</code> | OneDrive access token |
-| params.itemId | <code>String</code> | Item id |
-| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
-| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| params | <code>Object</code> |   |  |
+| params.accessToken | <code>String</code> |  | OneDrive access token |
+| params.itemId | <code>String</code> |  | Item id |
+| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
 ```javascript
@@ -210,8 +245,8 @@ List childrens
 | params | <code>Object</code> |  |  |
 | params.accessToken | <code>String</code> |  | OneDrive access token |
 | [params.itemId] | <code>String</code> | <code>root</code> | Item id |
-| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
-| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
 ```javascript
@@ -230,14 +265,14 @@ Update item metadata
 
 **Returns**: <code>Object</code> - Item object
 
-| Param | Type | Description |
-| --- | --- | --- |
-| params | <code>Object</code> |  |
-| params.accessToken | <code>String</code> | OneDrive access token |
-| params.itemId | <code>String</code> | Item id |
-| params.toUpdate | <code>Object</code> | Object to update |
-| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
-| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| params | <code>Object</code> |  |  |
+| params.accessToken | <code>String</code> |  | OneDrive access token |
+| params.itemId | <code>String</code> |  | Item id |
+| params.toUpdate | <code>Object</code> |  | Object to update |
+| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
 ```javascript
@@ -267,8 +302,8 @@ Create file with simple upload
 | [params.parentId] | <code>String</code> | <code>root</code> | Parent id |
 | [params.parentPath] | <code>String</code> |  | Parent path (if parentPath is defined, than parentId is ignored) |
 | params.readableStream | <code>Object</code> |  | Readable Stream with file's content |
-| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
-| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
 ```javascript
@@ -297,8 +332,8 @@ Create file with session upload. Use this for the files over 4MB. This is a sync
 | [params.parentId] | <code>String</code> | <code>root</code> | Parent id |
 | [params.parentPath] | <code>String</code> |  | Parent path (if parentPath is defined, than parentId is ignored) |
 | params.readableStream | <code>Object</code> |  | Readable Stream with file's content |
-| params.shared | <code>Boolean</code> | <code>false</code> | A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set. |
-| params.user | <code>String</code> |  | The user who shared the file. Must be set if params.shared is true. |
+| params.drive | <code>string</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 | [params.chunksToUpload] | <code>Number</code> | <code>20</code> | Chunks to upload per request. More chunks per request requires more RAM |
 
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Download item content partially. You must either provide `graphDownloadURL` or t
 
 If only the `itemId` is provided, the function will try to get the download URL for you with additional `getMetadata()` function call.
 
-**Returns**: <code>Object</code> - Readable stream with item's content
+**Returns**: <code>Promise</code> - A promise with the result is a `Readable stream` with partial item's content
 
 
 | Param | Type | Default | Description |
@@ -145,7 +145,7 @@ If only the `itemId` is provided, the function will try to get the download URL 
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 ```javascript
-var fileStream = oneDriveAPI.items.partialDownload({
+var partialPromise = oneDriveAPI.items.partialDownload({
   accessToken: accessToken,
   bytesFrom: 0, // start byte
   bytesTo: 1034, // to byte
@@ -155,7 +155,9 @@ var fileStream = oneDriveAPI.items.partialDownload({
   drive: 'me', // only be used when only `itemId` is provided
   driveId: 'me' // only be required when `drive` is provided
 });
-fileStream.pipe(SomeWritableStream);
+partialPromise.then(
+  (fileStream) => fileStream.pipe(SomeWritableStream)
+);
 ```
 
 ### items.customEndpoint

--- a/README.md
+++ b/README.md
@@ -249,12 +249,14 @@ List childrens
 | [params.itemId] | <code>String</code> | <code>root</code> | Item id |
 | params.drive | <code>String</code> | `'me'` | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
+| params.query | <code>String</code> | `undefined` | OData system query options. |
 
 
 ```javascript
 oneDriveAPI.items.listChildren({
   accessToken: accessToken,
-  itemId: createdFolder.id
+  itemId: createdFolder.id,
+  query: '?$filter=createdDateTime le 2020-07-07T12:56:51.577Z'
 }).then((childrens) => {
 // console.log(childrens);
 // returns body of https://dev.onedrive.com/items/list.htm#response

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Create Folder
 | params.accessToken | <code>String</code> |  | OneDrive access token |
 | [params.rootItemId] | <code>String</code> | <code>root</code> | Item id |
 | params.name | <code>String</code> |  | New folder name |
-| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.drive | <code>String</code> | `'me'` | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
@@ -89,7 +89,7 @@ Delete item (file or folder)
 | params | <code>Object</code> |  |
 | params.accessToken | <code>String</code> |  | OneDrive access token |
 | params.itemId | <code>String</code> |  | Item id |
-| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.drive | <code>String</code> | `'me'` | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
@@ -113,7 +113,7 @@ Download item content
 | params | <code>Object</code> |  |  |
 | params.accessToken | <code>String</code> | | OneDrive access token |
 | params.itemId | <code>String</code> |  | item id |
-| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.drive | <code>String</code> | `'me'` | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 ```javascript
@@ -141,7 +141,7 @@ If only the `itemId` is provided, the function will try to get the download URL 
 | params.itemId | <code>String</code> |  | item id. This parameter will be skipped if `graphDownloadURL` is provided. |
 | params.bytesFrom | <code>Number</code> | `0` | Starting download byte. |
 | params.bytesTo | <code>Number</code> | | Ending byte to download. Must be set |
-| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.drive | <code>String</code> | `'me'` | Only be used if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 ```javascript
@@ -222,7 +222,7 @@ Get items metadata (file or folder)
 | params | <code>Object</code> |   |  |
 | params.accessToken | <code>String</code> |  | OneDrive access token |
 | params.itemId | <code>String</code> |  | Item id |
-| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.drive | <code>String</code> | `'me'` | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
@@ -247,7 +247,7 @@ List childrens
 | params | <code>Object</code> |  |  |
 | params.accessToken | <code>String</code> |  | OneDrive access token |
 | [params.itemId] | <code>String</code> | <code>root</code> | Item id |
-| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.drive | <code>String</code> | `'me'` | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
@@ -273,7 +273,7 @@ Update item metadata
 | params.accessToken | <code>String</code> |  | OneDrive access token |
 | params.itemId | <code>String</code> |  | Item id |
 | params.toUpdate | <code>Object</code> |  | Object to update |
-| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.drive | <code>String</code> | `'me'` | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
@@ -304,7 +304,7 @@ Create file with simple upload
 | [params.parentId] | <code>String</code> | <code>root</code> | Parent id |
 | [params.parentPath] | <code>String</code> |  | Parent path (if parentPath is defined, than parentId is ignored) |
 | params.readableStream | <code>Object</code> |  | Readable Stream with file's content |
-| params.drive | <code>String</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.drive | <code>String</code> | `'me'` | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 
@@ -334,9 +334,10 @@ Create file with session upload. Use this for the files over 4MB. This is a sync
 | [params.parentId] | <code>String</code> | <code>root</code> | Parent id |
 | [params.parentPath] | <code>String</code> |  | Parent path (if parentPath is defined, than parentId is ignored) |
 | params.readableStream | <code>Object</code> |  | Readable Stream with file's content |
-| params.drive | <code>string</code> | `'me'` | Only required if only `params.itemId` is set and `params.graphDownloadURL` is undefined. If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
+| params.drive | <code>string</code> | `'me'` | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 | [params.chunksToUpload] | <code>Number</code> | <code>20</code> | Chunks to upload per request. More chunks per request requires more RAM |
+| process | <code>function</code> |  | A callback emit a variable represent the bytes that were transferred |
 
 
 ```javascript

--- a/lib/items/index.js
+++ b/lib/items/index.js
@@ -7,6 +7,7 @@ var listChildren = require('./listChildren'),
     update = require('./update'),
     getMetadata = require('./getMetadata'),
     download = require('./download'),
+    partialDownload = require('./partialDownload'),
     sync = require('./sync'),
     customEndpoint = require('./customEndpoint'),
     _delete = require('./delete');
@@ -20,6 +21,7 @@ module.exports = {
   update: update,
   getMetadata: getMetadata,
   download: download,
+  partialDownload: partialDownload,
   sync: sync,
   customEndpoint: customEndpoint,
   delete: _delete

--- a/lib/items/listChildren.js
+++ b/lib/items/listChildren.js
@@ -10,6 +10,7 @@ var userPathGenerator = require('../helpers/pathHelper');
  * @param {String} [params.itemId=root] Item id
  * @param {Boolean} [params.shared] A flag to indicated whether this files is owned by the user or shared from another user. If true params.user has to be set.
  * @param {String} [params.user] The user who shared the file. Must be set if params.shared is true.
+ * @param {String} [params.query] OData system query options.
  *
  * @return {Array} object of children items
  */
@@ -20,6 +21,7 @@ function listChildren(params) {
     throw new Error("Missing params.accessToken");
   }
 
+  params.query = params.query || '';
   params.itemId = params.itemId === undefined ? "root" : params.itemId;
   var userPath = userPathGenerator(params);
 

--- a/lib/items/partialDownload.js
+++ b/lib/items/partialDownload.js
@@ -13,7 +13,7 @@ var getMetadata = require('./getMetadata');
  * @param {Number} params.bytesFrom the starting byte to stream
  * @param {Number} params.bytesTo the ending byte of the stream
  *
- * @return {Object} Readable stream with partial item's content
+ * @return {Promise} A promise with the result is a `Readable stream` with partial item's content
  */
 
 function partialDownload(params) {
@@ -46,7 +46,7 @@ function partialDownload(params) {
 			uri: uri,
 			headers: headersRequest,
 		};
-		return request(options);
+		return Promise.resolve(request(options));
 	}
 
 	return getMetadata(params).then(meta => {

--- a/lib/items/partialDownload.js
+++ b/lib/items/partialDownload.js
@@ -1,0 +1,67 @@
+// partialDownload.js
+var request = require('request');
+var getMetadata = require('./getMetadata');
+
+/**
+ * @function partialDownload
+ * @description partially download item content
+ *
+ * @param {Object} params
+ * @param {String} params.accessToken OneDrive access token
+ * @param {String} params.graphDownloadURL The URL string from `@microsoft.graph.downloadUrl`
+ * @param {String} params.itemId item id. If `graphDownloadURL` is provided, this parameter will be ignored
+ * @param {Number} params.bytesFrom the starting byte to stream
+ * @param {Number} params.bytesTo the ending byte of the stream
+ *
+ * @return {Object} Readable stream with partial item's content
+ */
+
+function partialDownload(params) {
+
+	if (!params.accessToken) {
+		throw new Error("Missing params.accessToken");
+	}
+
+	if (!params.graphDownloadURL && !params.itemId) {
+		throw new Error("Missing both params.graphDownloadURL and params.itemId");
+	}
+
+	if (!params.bytesFrom) {
+		params.bytesFrom = 0;
+	}
+
+	if (!params.bytesTo) {
+		throw new Error("Missing params.bytesTo");
+	}
+
+	var headersRequest = {
+		Authorization: "Bearer " + params.accessToken,
+		Range: `bytes=${params.bytesFrom}-${params.bytesTo}`,
+	};
+
+	var uri = params.graphDownloadURL;
+	if (uri) {
+		const options = {
+			method: 'GET',
+			uri: uri,
+			headers: headersRequest,
+		};
+		return request(options);
+	}
+
+	return getMetadata(params).then(meta => {
+		const downloadURL = meta["@microsoft.graph.downloadUrl"];
+		if (!downloadURL) {
+			throw new Error("Item does not have @microsoft.graph.downloadUrl field")
+		}
+
+		var options = {
+			method: 'GET',
+			uri: downloadURL,
+			headers: headersRequest,
+		}
+		return request(options);
+	})
+}
+
+module.exports = partialDownload;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "onedrive-api",
-  "version": "0.3.4",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -561,12 +561,6 @@
         "tweetnacl": "~0.14.0"
       }
     },
-    "string-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/string-stream/-/string-stream-0.0.7.tgz",
-      "integrity": "sha1-z83oJ5n6YvMDQpqqeTNu6INDMv4=",
-      "dev": true
-    },
     "string-to-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onedrive-api",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "OneDrive module for communicating with oneDrive API. Built using functional programming pattern",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "faker": "^3.1.0",
     "install": "0.6.1",
     "mocha": "^5.2.0",
-    "string-stream": "0.0.7",
     "string-to-stream": "^1.1.1"
   }
 }

--- a/test/e2e/items/download.test.js
+++ b/test/e2e/items/download.test.js
@@ -1,49 +1,48 @@
 // download.test.js
 
-const faker = require("faker");
-const stringStream = require("string-to-stream");
+var faker = require('faker'),
+    stringStream = require('string-to-stream');
 
-describe("download", function () {
+describe("download", function(){
+
   var filename, readableStream, fileContent, createdFile;
 
-  before(function (done) {
+  before(function(done){
+
     filename = "test-download-" + faker.random.word();
     fileContent = faker.lorem.paragraphs();
     readableStream = stringStream(fileContent);
 
-    oneDrive.items
-      .uploadSimple({
-        accessToken: accessToken,
-        filename: filename,
-        readableStream: readableStream,
-      })
-      .then(function (item) {
-        createdFile = item;
-        done();
-      })
-      .catch(errorHandler(done));
+    oneDrive.items.uploadSimple({
+      accessToken: accessToken,
+      filename: filename,
+      readableStream: readableStream
+    }).then(function(item){
+      createdFile = item;
+      done();
+    }).catch(errorHandler(done));
+
   });
 
-  after(function (done) {
-    oneDrive.items
-      .delete({
-        accessToken: accessToken,
-        itemId: createdFile.id,
-      })
-      .then(function (_item) {
-        done();
-      })
-      .catch(errorHandler(done));
-  });
+  after(function(done){
+
+    oneDrive.items.delete({
+      accessToken: accessToken,
+      itemId: createdFile.id
+    }).then(function(_item){
+      done();
+    }).catch(errorHandler(done));
+
+  })
 
   it("Should download Simple file using Stream", function (done) {
     var partialString = "";
     var fileStream = oneDrive.items.download({
       accessToken: accessToken,
-      itemId: createdFile.id,
+      itemId: createdFile.id
     });
 
-    fileStream.on("data", function (data) {
+    fileStream.on('data', function(data){
       partialString += data.toString();
     });
 
@@ -52,8 +51,10 @@ describe("download", function () {
       done();
     });
 
-    fileStream.on("error", function (err) {
+    fileStream.on('error', function(err){
       errorHandler(done)(err);
     });
+
   });
+
 });

--- a/test/e2e/items/download.test.js
+++ b/test/e2e/items/download.test.js
@@ -1,56 +1,59 @@
 // download.test.js
 
-var faker = require('faker'),
-    stringStream = require('string-stream');
+const faker = require("faker");
+const stringStream = require("string-to-stream");
 
-describe("download", function(){
-  
+describe("download", function () {
   var filename, readableStream, fileContent, createdFile;
-  
-  before(function(done){
-    
+
+  before(function (done) {
     filename = "test-download-" + faker.random.word();
     fileContent = faker.lorem.paragraphs();
-    readableStream = new stringStream(fileContent);
-    
-    oneDrive.items.uploadSimple({
-      accessToken: accessToken,
-      filename: filename,
-      readableStream: readableStream
-    }).then(function(item){
-      createdFile = item;
-      done();
-    }).catch(errorHandler(done));
-    
+    readableStream = stringStream(fileContent);
+
+    oneDrive.items
+      .uploadSimple({
+        accessToken: accessToken,
+        filename: filename,
+        readableStream: readableStream,
+      })
+      .then(function (item) {
+        createdFile = item;
+        done();
+      })
+      .catch(errorHandler(done));
   });
-  
-  after(function(done){
-    
-    oneDrive.items.delete({
-      accessToken: accessToken,
-      itemId: createdFile.id
-    }).then(function(_item){
-      done();
-    }).catch(errorHandler(done));
-    
-  })
-  
-  it("Should download Simple file using Stream", function(done){
-    
+
+  after(function (done) {
+    oneDrive.items
+      .delete({
+        accessToken: accessToken,
+        itemId: createdFile.id,
+      })
+      .then(function (_item) {
+        done();
+      })
+      .catch(errorHandler(done));
+  });
+
+  it("Should download Simple file using Stream", function (done) {
+    var partialString = "";
     var fileStream = oneDrive.items.download({
       accessToken: accessToken,
-      itemId: createdFile.id
+      itemId: createdFile.id,
     });
-    
-    fileStream.on('data', function(data){
-      expect(data.toString()).to.be.equal(fileContent);
+
+    fileStream.on("data", function (data) {
+      partialString += data.toString();
+    });
+
+    fileStream.on("end", function () {
+      expect(partialString).to.be.equal(fileContent);
       done();
     });
-    
-    fileStream.on('error', function(err){
+
+    fileStream.on("error", function (err) {
       errorHandler(done)(err);
     });
-    
   });
-  
 });

--- a/test/e2e/items/partialDownload.test.js
+++ b/test/e2e/items/partialDownload.test.js
@@ -1,61 +1,66 @@
 // partialDownload.test.js
 
-var faker = require('faker'),
-    stringStream = require('string-stream');
+const faker = require("faker");
+const stringStream = require("string-to-stream");
 
-describe("partialDownload", function(){
-  
+describe("partialDownload", function () {
   var filename, readableStream, fileContent, createdFile;
-  
-  before(function(done){
-    
+
+  before(function (done) {
     filename = "test-download-" + faker.random.word();
     fileContent = faker.lorem.paragraphs();
-    readableStream = new stringStream(fileContent);
-    
-    oneDrive.items.uploadSimple({
-      accessToken: accessToken,
-      filename: filename,
-      readableStream: readableStream
-    }).then(function(item){
-      createdFile = item;
-      done();
-    }).catch(errorHandler(done));
-    
+    readableStream = stringStream(fileContent);
+
+    oneDrive.items
+      .uploadSimple({
+        accessToken: accessToken,
+        filename: filename,
+        readableStream: readableStream,
+      })
+      .then(function (item) {
+        createdFile = item;
+        done();
+      })
+      .catch(errorHandler(done));
   });
-  
-  after(function(done){
-    
-    oneDrive.items.delete({
-      accessToken: accessToken,
-      itemId: createdFile.id
-    }).then(function(_item){
-      done();
-    }).catch(errorHandler(done));
-    
-  })
-  
-  it("Should download Simple file using Stream", function(done){
-    
-    var fileStream = oneDrive.items.partialDownload({
+
+  after(function (done) {
+    oneDrive.items
+      .delete({
+        accessToken: accessToken,
+        itemId: createdFile.id,
+      })
+      .then(function (_item) {
+        done();
+      })
+      .catch(errorHandler(done));
+  });
+
+  it("Should partial download Simple file using Stream", function (done) {
+    var partialPromise = oneDrive.items.partialDownload({
       accessToken: accessToken,
       itemId: createdFile.id,
       bytesFrom: 0,
       bytesTo: createdFile.size,
     });
-    var partialString = '';
-    fileStream.on('data', function(data){
-      partialString += data.toString();
-    });
-    fileStream.on('end', function () {
-      expect(partialString).to.be.equal(fileContent);
-      done();
-    })
-    
-    fileStream.on('error', function(err){
-      errorHandler(done)(err);
-    });
-    
+    partialPromise
+      .then((fileStream) => {
+        var partialString = "";
+        fileStream.on("data", function (data) {
+          partialString += data.toString();
+        });
+
+        fileStream.on("end", function () {
+          expect(partialString).to.be.equal(fileContent);
+          done();
+        });
+
+        fileStream.on("error", function (err) {
+          errorHandler(done)(err);
+        });
+      })
+      .catch((error) => {
+        errorHandler(done)(error);
+      });
   });
-  
 });

--- a/test/e2e/items/partialDownload.test.js
+++ b/test/e2e/items/partialDownload.test.js
@@ -1,0 +1,61 @@
+// partialDownload.test.js
+
+var faker = require('faker'),
+    stringStream = require('string-stream');
+
+describe("partialDownload", function(){
+  
+  var filename, readableStream, fileContent, createdFile;
+  
+  before(function(done){
+    
+    filename = "test-download-" + faker.random.word();
+    fileContent = faker.lorem.paragraphs();
+    readableStream = new stringStream(fileContent);
+    
+    oneDrive.items.uploadSimple({
+      accessToken: accessToken,
+      filename: filename,
+      readableStream: readableStream
+    }).then(function(item){
+      createdFile = item;
+      done();
+    }).catch(errorHandler(done));
+    
+  });
+  
+  after(function(done){
+    
+    oneDrive.items.delete({
+      accessToken: accessToken,
+      itemId: createdFile.id
+    }).then(function(_item){
+      done();
+    }).catch(errorHandler(done));
+    
+  })
+  
+  it("Should download Simple file using Stream", function(done){
+    
+    var fileStream = oneDrive.items.partialDownload({
+      accessToken: accessToken,
+      itemId: createdFile.id,
+      bytesFrom: 0,
+      bytesTo: createdFile.size,
+    });
+    var partialString = '';
+    fileStream.on('data', function(data){
+      partialString += data.toString();
+    });
+    fileStream.on('end', function () {
+      expect(partialString).to.be.equal(fileContent);
+      done();
+    })
+    
+    fileStream.on('error', function(err){
+      errorHandler(done)(err);
+    });
+    
+  });
+  
+});

--- a/test/e2e/items/uploadSession.test.js
+++ b/test/e2e/items/uploadSession.test.js
@@ -5,52 +5,51 @@ const stringStream = require("string-to-stream");
 
 describe("uploadSession", function () {
   describe("Should upload Session 1kB file using Stream in root directory", function () {
-    var createdFile;
+    var createdFile
 
     it("Should upload Session 1kB file using Stream in root directory", function (done) {
       const filename = "test-uploadSession-" + faker.random.word();
       // 1Kb
-      const fileContent = "a".repeat(1 * 1024);
+      const fileContent = 'a'.repeat(1 * 1024)
       const readableStream = stringStream(fileContent);
 
-      oneDrive.items
-        .uploadSession({
-          accessToken: accessToken,
-          filename: filename,
-          readableStream: readableStream,
-          fileSize: fileContent.length,
-        })
-        .then(function (item) {
-          expect(item.id).to.be.a("String");
-          expect(item.name).to.be.a("String");
-          expect(item.size).to.be.a("Number");
-          expect(item.size).to.be.at.least(1);
-          expect(item.id).to.be.a("String");
-          createdFile = item;
-          done();
-        })
-        .catch((err) => {
-          console.error("Error Handled");
-          console.error(err);
-          errorHandler(done);
-        });
+      oneDrive.items.uploadSession({
+        accessToken: accessToken,
+        filename: filename,
+        readableStream: readableStream,
+        fileSize: fileContent.length
+      }).then(function (item) {
+        expect(item.id).to.be.a('String');
+        expect(item.name).to.be.a('String');
+        expect(item.size).to.be.a('Number');
+        expect(item.size).to.be.at.least(1);
+        expect(item.id).to.be.a('String');
+        createdFile = item;
+        done();
+      }).catch((err) => {
+        console.error('Error Handled')
+        console.error(err)
+        errorHandler(done)
+      }
+      );
+
     });
 
     after(function (done) {
-      oneDrive.items
-        .delete({
-          accessToken: accessToken,
-          itemId: createdFile.id,
-        })
-        .then(function (_folder) {
-          done();
-        })
-        .catch(errorHandler(done));
+
+      oneDrive.items.delete({
+        accessToken: accessToken,
+        itemId: createdFile.id
+      }).then(function (_folder) {
+        done();
+      }).catch(errorHandler(done));
+
     });
-  });
+
+  })
 
   describe("Should upload Session 10MB file using Stream", function () {
-    let createdFile;
+    var createdFile
 
     it("Should upload Session 10MB file using Stream", function (done) {
       const filename = "test-uploadSession-" + faker.random.word();
@@ -65,10 +64,9 @@ describe("uploadSession", function () {
           accessToken: accessToken,
           filename: filename,
           readableStream: readableStream,
-          fileSize: fsStat.size,
+          fileSize: fsStat.size
         })
         .then(function (item) {
-          console.log('file uploaded - uploadSession');
           expect(item.id).to.be.a("String");
           expect(item.name).to.be.a("String");
           expect(item.size).to.be.a("Number");
@@ -77,22 +75,24 @@ describe("uploadSession", function () {
           createdFile = item;
           done();
         })
-        .catch(errorHandler(done));
+        .catch(err => {
+          errorHandler(done);
+        });
     });
     after(function (done) {
-      oneDrive.items
-        .delete({
-          accessToken: accessToken,
-          itemId: createdFile.id,
-        })
-        .then(function (_folder) {
-          done();
-        })
-        .catch((err) => errorHandler(done)(err));
+
+      oneDrive.items.delete({
+        accessToken: accessToken,
+        itemId: createdFile.id
+      }).then(function (_folder) {
+        done();
+      }).catch(errorHandler(done));
+
     });
   });
 
   describe("Should upload Session 1kb file inside a folder using parentId", function () {
+
     var filename, readableStream, fileContent, folderName, createdFolder;
 
     before(function (done) {
@@ -105,7 +105,7 @@ describe("uploadSession", function () {
         .createFolder({
           accessToken: accessToken,
           rootItemId: "root",
-          name: folderName,
+          name: folderName
         })
         .then(function (folder) {
           createdFolder = folder;
@@ -124,7 +124,7 @@ describe("uploadSession", function () {
           filename: filename,
           readableStream: readableStream,
           fileSize: fileContent.length,
-          parentId: createdFolder.id,
+          parentId: createdFolder.id
         })
         .then(function (item) {
           expect(item.id).to.be.a("String");
@@ -135,32 +135,32 @@ describe("uploadSession", function () {
           createdFile = item;
           done();
         })
-        .catch((err) => {
+        .catch(err => {
           console.error(err);
           errorHandler(done);
         });
     });
 
     after(function (done) {
-      oneDrive.items
-        .delete({
+
+      oneDrive.items.delete({
+        accessToken: accessToken,
+        itemId: createdFile.id
+      }).then(function () {
+        return oneDrive.items.delete({
           accessToken: accessToken,
-          itemId: createdFile.id,
-        })
-        .then(function () {
-          return oneDrive.items.delete({
-            accessToken: accessToken,
-            itemId: createdFolder.id,
-          });
-        })
-        .then(function (_folder) {
-          done();
-        })
-        .catch(errorHandler(done));
+          itemId: createdFolder.id
+        });
+      }).then(function (_folder) {
+        done();
+      }).catch(errorHandler(done));
+
     });
-  });
+
+  })
 
   describe("Should upload Session 1kb file inside a folder using parentPath", function () {
+
     var filename, readableStream, fileContent, folderName, createdFolder;
 
     before(function (done) {
@@ -173,7 +173,7 @@ describe("uploadSession", function () {
         .createFolder({
           accessToken: accessToken,
           rootItemId: "root",
-          name: folderName,
+          name: folderName
         })
         .then(function (folder) {
           createdFolder = folder;
@@ -189,7 +189,7 @@ describe("uploadSession", function () {
           filename: filename,
           readableStream: readableStream,
           fileSize: fileContent.length,
-          parentPath: folderName,
+          parentPath: folderName
         })
         .then(function (item) {
           expect(item.id).to.be.a("String");
@@ -200,28 +200,27 @@ describe("uploadSession", function () {
           createdFile = item;
           done();
         })
-        .catch((err) => {
-          console.error(err);
+        .catch(err => {
+          console.error(err)
           errorHandler(done);
         });
     });
 
     after(function (done) {
-      oneDrive.items
-        .delete({
+
+      oneDrive.items.delete({
+        accessToken: accessToken,
+        itemId: createdFile.id
+      }).then(function () {
+        return oneDrive.items.delete({
           accessToken: accessToken,
-          itemId: createdFile.id,
-        })
-        .then(function () {
-          return oneDrive.items.delete({
-            accessToken: accessToken,
-            itemId: createdFolder.id,
-          });
-        })
-        .then(function (_folder) {
-          done();
-        })
-        .catch(errorHandler(done));
+          itemId: createdFolder.id
+        });
+      }).then(function (_folder) {
+        done();
+      }).catch(errorHandler(done));
+
     });
-  });
+
+  })
 });

--- a/test/e2e/items/uploadSession.test.js
+++ b/test/e2e/items/uploadSession.test.js
@@ -5,58 +5,59 @@ const stringStream = require("string-to-stream");
 
 describe("uploadSession", function () {
   describe("Should upload Session 1kB file using Stream in root directory", function () {
-    var createdFile
+    var createdFile;
 
     it("Should upload Session 1kB file using Stream in root directory", function (done) {
       const filename = "test-uploadSession-" + faker.random.word();
       // 1Kb
-      const fileContent = 'a'.repeat(1 * 1024)
+      const fileContent = "a".repeat(1 * 1024);
       const readableStream = stringStream(fileContent);
 
-      oneDrive.items.uploadSession({
-        accessToken: accessToken,
-        filename: filename,
-        readableStream: readableStream,
-        fileSize: fileContent.length
-      }).then(function (item) {
-        expect(item.id).to.be.a('String');
-        expect(item.name).to.be.a('String');
-        expect(item.size).to.be.a('Number');
-        expect(item.size).to.be.at.least(1);
-        expect(item.id).to.be.a('String');
-        createdFile = item;
-        done();
-      }).catch((err) => {
-        console.error('Error Handled')
-        console.error(err)
-        errorHandler(done)
-      }
-      );
-
+      oneDrive.items
+        .uploadSession({
+          accessToken: accessToken,
+          filename: filename,
+          readableStream: readableStream,
+          fileSize: fileContent.length,
+        })
+        .then(function (item) {
+          expect(item.id).to.be.a("String");
+          expect(item.name).to.be.a("String");
+          expect(item.size).to.be.a("Number");
+          expect(item.size).to.be.at.least(1);
+          expect(item.id).to.be.a("String");
+          createdFile = item;
+          done();
+        })
+        .catch((err) => {
+          console.error("Error Handled");
+          console.error(err);
+          errorHandler(done);
+        });
     });
 
     after(function (done) {
-
-      oneDrive.items.delete({
-        accessToken: accessToken,
-        itemId: createdFile.id
-      }).then(function (_folder) {
-        done();
-      }).catch(errorHandler(done));
-
+      oneDrive.items
+        .delete({
+          accessToken: accessToken,
+          itemId: createdFile.id,
+        })
+        .then(function (_folder) {
+          done();
+        })
+        .catch(errorHandler(done));
     });
-
-  })
+  });
 
   describe("Should upload Session 10MB file using Stream", function () {
-    var createdFile
+    let createdFile;
 
     it("Should upload Session 10MB file using Stream", function (done) {
       const filename = "test-uploadSession-" + faker.random.word();
       // 10MB
       const fs = require("fs");
       const path = require("path");
-      const exampleFilePath = path.join(__dirname, "../../example-data//10MB_file.txt");
+      const exampleFilePath = path.join(__dirname, "../../example-data/10MB_file.txt");
       const readableStream = fs.createReadStream(exampleFilePath);
       const fsStat = fs.statSync(exampleFilePath);
       oneDrive.items
@@ -64,9 +65,10 @@ describe("uploadSession", function () {
           accessToken: accessToken,
           filename: filename,
           readableStream: readableStream,
-          fileSize: fsStat.size
+          fileSize: fsStat.size,
         })
         .then(function (item) {
+          console.log('file uploaded - uploadSession');
           expect(item.id).to.be.a("String");
           expect(item.name).to.be.a("String");
           expect(item.size).to.be.a("Number");
@@ -75,37 +77,35 @@ describe("uploadSession", function () {
           createdFile = item;
           done();
         })
-        .catch(err => {
-          errorHandler(done);
-        });
+        .catch(errorHandler(done));
     });
     after(function (done) {
-
-      oneDrive.items.delete({
-        accessToken: accessToken,
-        itemId: createdFile.id
-      }).then(function (_folder) {
-        done();
-      }).catch(errorHandler(done));
-
+      oneDrive.items
+        .delete({
+          accessToken: accessToken,
+          itemId: createdFile.id,
+        })
+        .then(function (_folder) {
+          done();
+        })
+        .catch((err) => errorHandler(done)(err));
     });
-  })
+  });
 
   describe("Should upload Session 1kb file inside a folder using parentId", function () {
-
     var filename, readableStream, fileContent, folderName, createdFolder;
 
     before(function (done) {
       filename = "test-uploadSession-" + faker.random.word();
       fileContent = "a".repeat(1 * 1024);
-      readableStream = new stringStream(fileContent);
+      readableStream = stringStream(fileContent);
       folderName = "test-uploadSessionFolder-" + faker.random.word();
 
       oneDrive.items
         .createFolder({
           accessToken: accessToken,
           rootItemId: "root",
-          name: folderName
+          name: folderName,
         })
         .then(function (folder) {
           createdFolder = folder;
@@ -124,7 +124,7 @@ describe("uploadSession", function () {
           filename: filename,
           readableStream: readableStream,
           fileSize: fileContent.length,
-          parentId: createdFolder.id
+          parentId: createdFolder.id,
         })
         .then(function (item) {
           expect(item.id).to.be.a("String");
@@ -135,45 +135,45 @@ describe("uploadSession", function () {
           createdFile = item;
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           console.error(err);
           errorHandler(done);
         });
     });
 
     after(function (done) {
-
-      oneDrive.items.delete({
-        accessToken: accessToken,
-        itemId: createdFile.id
-      }).then(function () {
-        return oneDrive.items.delete({
+      oneDrive.items
+        .delete({
           accessToken: accessToken,
-          itemId: createdFolder.id
-        });
-      }).then(function (_folder) {
-        done();
-      }).catch(errorHandler(done));
-
+          itemId: createdFile.id,
+        })
+        .then(function () {
+          return oneDrive.items.delete({
+            accessToken: accessToken,
+            itemId: createdFolder.id,
+          });
+        })
+        .then(function (_folder) {
+          done();
+        })
+        .catch(errorHandler(done));
     });
-
-  })
+  });
 
   describe("Should upload Session 1kb file inside a folder using parentPath", function () {
-
     var filename, readableStream, fileContent, folderName, createdFolder;
 
     before(function (done) {
       filename = "test-uploadSession-" + faker.random.word();
       fileContent = "a".repeat(1 * 1024);
-      readableStream = new stringStream(fileContent);
+      readableStream = stringStream(fileContent);
       folderName = "test-uploadSessionFolder-" + faker.random.word();
 
       oneDrive.items
         .createFolder({
           accessToken: accessToken,
           rootItemId: "root",
-          name: folderName
+          name: folderName,
         })
         .then(function (folder) {
           createdFolder = folder;
@@ -189,7 +189,7 @@ describe("uploadSession", function () {
           filename: filename,
           readableStream: readableStream,
           fileSize: fileContent.length,
-          parentPath: folderName
+          parentPath: folderName,
         })
         .then(function (item) {
           expect(item.id).to.be.a("String");
@@ -200,27 +200,28 @@ describe("uploadSession", function () {
           createdFile = item;
           done();
         })
-        .catch(err => {
-          console.error(err)
+        .catch((err) => {
+          console.error(err);
           errorHandler(done);
         });
     });
 
     after(function (done) {
-
-      oneDrive.items.delete({
-        accessToken: accessToken,
-        itemId: createdFile.id
-      }).then(function () {
-        return oneDrive.items.delete({
+      oneDrive.items
+        .delete({
           accessToken: accessToken,
-          itemId: createdFolder.id
-        });
-      }).then(function (_folder) {
-        done();
-      }).catch(errorHandler(done));
-
+          itemId: createdFile.id,
+        })
+        .then(function () {
+          return oneDrive.items.delete({
+            accessToken: accessToken,
+            itemId: createdFolder.id,
+          });
+        })
+        .then(function (_folder) {
+          done();
+        })
+        .catch(errorHandler(done));
     });
-
-  })
+  });
 });

--- a/test/e2e/items/uploadSession.test.js
+++ b/test/e2e/items/uploadSession.test.js
@@ -59,14 +59,19 @@ describe("uploadSession", function () {
       const exampleFilePath = path.join(__dirname, "../../example-data/10MB_file.txt");
       const readableStream = fs.createReadStream(exampleFilePath);
       const fsStat = fs.statSync(exampleFilePath);
+      const processReport = (process) => console.log(
+        `Uploaded bytes: ${process}/${fsStat.size} (${((process / fsStat.size) * 100).toFixed(3)})%`
+      );
       oneDrive.items
-        .uploadSession({
-          accessToken: accessToken,
-          filename: filename,
-          readableStream: readableStream,
-          fileSize: fsStat.size
-        })
-        .then(function (item) {
+        .uploadSession(
+          {
+            accessToken: accessToken,
+            filename: filename,
+            readableStream: readableStream,
+            fileSize: fsStat.size
+          },
+          processReport
+        ).then(function (item) {
           expect(item.id).to.be.a("String");
           expect(item.name).to.be.a("String");
           expect(item.size).to.be.a("Number");

--- a/test/e2e/items/uploadSimple.test.js
+++ b/test/e2e/items/uploadSimple.test.js
@@ -1,91 +1,89 @@
 // uploadSimple.test.js
 
-const faker = require("faker");
-const stringStream = require("string-to-stream");
+var faker = require('faker'),
+    stringStream = require('string-to-stream');
 
-describe("uploadSimple", function () {
+describe("uploadSimple", function(){
+
   var filename, readableStream, fileContent, createdFile, folderName, createdFolder, createdFile2;
 
-  before(function (done) {
+  before(function(done){
+
     filename = "test-uploadSimple-" + faker.random.word();
     fileContent = faker.lorem.paragraphs();
     readableStream = stringStream(fileContent);
     folderName = "test-uploadSimpleFolder-" + faker.random.word();
 
-    oneDrive.items
-      .createFolder({
-        accessToken: accessToken,
-        rootItemId: "root",
-        name: folderName,
-      })
-      .then(function (folder) {
-        createdFolder = folder;
-        done();
-      })
-      .catch(done);
+    oneDrive.items.createFolder({
+      accessToken: accessToken,
+      rootItemId: "root",
+      name: folderName
+    }).then(function(folder){
+      createdFolder = folder;
+      done();
+    }).catch(done);
+
   });
 
-  after(function (done) {
-    oneDrive.items
-      .delete({
+  after(function(done){
+
+    oneDrive.items.delete({
+      accessToken: accessToken,
+      itemId: createdFile.id
+    }).then(function(_item){
+       return oneDrive.items.delete({
         accessToken: accessToken,
-        itemId: createdFile.id,
-      })
-      .then(function (_item) {
-        return oneDrive.items.delete({
-          accessToken: accessToken,
-          itemId: createdFile2.id,
-        });
-      })
-      .then(function () {
-        return oneDrive.items.delete({
-          accessToken: accessToken,
-          itemId: createdFolder.id,
-        });
-      })
-      .then(function (_folder) {
-        done();
-      })
-      .catch(errorHandler(done));
+        itemId: createdFile2.id
+      });
+    })
+    .then(function(){
+      return oneDrive.items.delete({
+        accessToken: accessToken,
+        itemId: createdFolder.id
+      });
+    }).then(function(_folder){
+      done();
+    }).catch(errorHandler(done));
+
   });
 
-  it("Should upload Simple file using Stream", function (done) {
-    oneDrive.items
-      .uploadSimple({
-        accessToken: accessToken,
-        filename: filename,
-        readableStream: readableStream,
-      })
-      .then(function (item) {
-        expect(item.id).to.be.a("String");
-        expect(item.name).to.be.a("String");
-        expect(item.size).to.be.a("Number");
-        expect(item.size).to.be.at.least(1);
-        expect(item.id).to.be.a("String");
-        createdFile = item;
-        done();
-      })
-      .catch(errorHandler(done));
+  it("Should upload Simple file using Stream", function(done){
+
+    oneDrive.items.uploadSimple({
+      accessToken: accessToken,
+      filename: filename,
+      readableStream: readableStream
+    }).then(function(item){
+
+      expect(item.id).to.be.a('String');
+      expect(item.name).to.be.a('String');
+      expect(item.size).to.be.a('Number');
+      expect(item.size).to.be.at.least(1);
+      expect(item.id).to.be.a('String');
+      createdFile = item;
+      done();
+    }).catch(errorHandler(done));
+
   });
 
-  it("Should upload Simple file using Stream and parentPath", function (done) {
-    oneDrive.items
-      .uploadSimple({
-        accessToken: accessToken,
-        filename: filename,
-        parentPath: folderName,
-        readableStream: readableStream,
-      })
-      .then(function (item) {
-        console.log('file uploaded - uploadSimple -', item);
-        expect(item.id).to.be.a("String");
-        expect(item.name).to.be.a("String");
-        expect(item.size).to.be.a("Number");
-        expect(item.size).to.be.at.least(1);
-        expect(item.id).to.be.a("String");
-        createdFile2 = item;
-        done();
-      })
-      .catch(errorHandler(done));
+  it("Should upload Simple file using Stream and parentPath", function(done){
+
+    oneDrive.items.uploadSimple({
+      accessToken: accessToken,
+      filename: filename,
+      parentPath: folderName,
+      readableStream: readableStream
+    }).then(function(item){
+
+      expect(item.id).to.be.a('String');
+      expect(item.name).to.be.a('String');
+      expect(item.size).to.be.a('Number');
+      expect(item.size).to.be.at.least(1);
+      expect(item.id).to.be.a('String');
+      createdFile2 = item;
+      done();
+    }).catch(errorHandler(done));
+
   });
+
 });

--- a/test/e2e/items/uploadSimple.test.js
+++ b/test/e2e/items/uploadSimple.test.js
@@ -1,89 +1,91 @@
 // uploadSimple.test.js
 
-var faker = require('faker'),
-    stringStream = require('string-stream');
+const faker = require("faker");
+const stringStream = require("string-to-stream");
 
-describe("uploadSimple", function(){
-  
+describe("uploadSimple", function () {
   var filename, readableStream, fileContent, createdFile, folderName, createdFolder, createdFile2;
-  
-  before(function(done){
-    
+
+  before(function (done) {
     filename = "test-uploadSimple-" + faker.random.word();
     fileContent = faker.lorem.paragraphs();
-    readableStream = new stringStream(fileContent);
+    readableStream = stringStream(fileContent);
     folderName = "test-uploadSimpleFolder-" + faker.random.word();
-    
-    oneDrive.items.createFolder({
-      accessToken: accessToken,
-      rootItemId: "root",
-      name: folderName
-    }).then(function(folder){
-      createdFolder = folder;
-      done();
-    }).catch(done);
-    
-  });
-  
-  after(function(done){
-    
-    oneDrive.items.delete({
-      accessToken: accessToken,
-      itemId: createdFile.id
-    }).then(function(_item){
-       return oneDrive.items.delete({
+
+    oneDrive.items
+      .createFolder({
         accessToken: accessToken,
-        itemId: createdFile2.id
-      });      
-    })
-    .then(function(){
-      return oneDrive.items.delete({
+        rootItemId: "root",
+        name: folderName,
+      })
+      .then(function (folder) {
+        createdFolder = folder;
+        done();
+      })
+      .catch(done);
+  });
+
+  after(function (done) {
+    oneDrive.items
+      .delete({
         accessToken: accessToken,
-        itemId: createdFolder.id
-      });
-    }).then(function(_folder){
-      done();
-    }).catch(errorHandler(done));
-    
+        itemId: createdFile.id,
+      })
+      .then(function (_item) {
+        return oneDrive.items.delete({
+          accessToken: accessToken,
+          itemId: createdFile2.id,
+        });
+      })
+      .then(function () {
+        return oneDrive.items.delete({
+          accessToken: accessToken,
+          itemId: createdFolder.id,
+        });
+      })
+      .then(function (_folder) {
+        done();
+      })
+      .catch(errorHandler(done));
   });
-  
-  it("Should upload Simple file using Stream", function(done){
-    
-    oneDrive.items.uploadSimple({
-      accessToken: accessToken,
-      filename: filename,
-      readableStream: readableStream
-    }).then(function(item){
-      
-      expect(item.id).to.be.a('String');
-      expect(item.name).to.be.a('String');
-      expect(item.size).to.be.a('Number');
-      expect(item.size).to.be.at.least(1);
-      expect(item.id).to.be.a('String');
-      createdFile = item;
-      done();
-    }).catch(errorHandler(done));
-    
+
+  it("Should upload Simple file using Stream", function (done) {
+    oneDrive.items
+      .uploadSimple({
+        accessToken: accessToken,
+        filename: filename,
+        readableStream: readableStream,
+      })
+      .then(function (item) {
+        expect(item.id).to.be.a("String");
+        expect(item.name).to.be.a("String");
+        expect(item.size).to.be.a("Number");
+        expect(item.size).to.be.at.least(1);
+        expect(item.id).to.be.a("String");
+        createdFile = item;
+        done();
+      })
+      .catch(errorHandler(done));
   });
-  
-  it("Should upload Simple file using Stream and parentPath", function(done){
-    
-    oneDrive.items.uploadSimple({
-      accessToken: accessToken,
-      filename: filename,
-      parentPath: folderName,
-      readableStream: readableStream
-    }).then(function(item){
-      
-      expect(item.id).to.be.a('String');
-      expect(item.name).to.be.a('String');
-      expect(item.size).to.be.a('Number');
-      expect(item.size).to.be.at.least(1);
-      expect(item.id).to.be.a('String');
-      createdFile2 = item;
-      done();
-    }).catch(errorHandler(done));
-    
+
+  it("Should upload Simple file using Stream and parentPath", function (done) {
+    oneDrive.items
+      .uploadSimple({
+        accessToken: accessToken,
+        filename: filename,
+        parentPath: folderName,
+        readableStream: readableStream,
+      })
+      .then(function (item) {
+        console.log('file uploaded - uploadSimple -', item);
+        expect(item.id).to.be.a("String");
+        expect(item.name).to.be.a("String");
+        expect(item.size).to.be.a("Number");
+        expect(item.size).to.be.at.least(1);
+        expect(item.id).to.be.a("String");
+        createdFile2 = item;
+        done();
+      })
+      .catch(errorHandler(done));
   });
-  
 });

--- a/test/e2e/items/uploadSimple.test.js
+++ b/test/e2e/items/uploadSimple.test.js
@@ -67,7 +67,8 @@ describe("uploadSimple", function(){
   });
 
   it("Should upload Simple file using Stream and parentPath", function(done){
-
+    // restart the stream
+    readableStream = stringStream(fileContent);
     oneDrive.items.uploadSimple({
       accessToken: accessToken,
       filename: filename,


### PR DESCRIPTION
Reason and basic implementation are described in #27.

Since I am not familiar with the `request` package (tested with `node-fetch` OK ) so there might be some mistake.

<s>Also, because there is no guide to perform testing and stuff and I have tried to test it, it seems like the `uploadSimple` API has some issue on the test case with `parentPath`.
Can you check that?</s>

testing with E2E seems to be fine.

> ![image](https://user-images.githubusercontent.com/29449869/90978399-e25f8080-e577-11ea-84dc-5df82c75b112.png)
