### PR TITLE
fix/circleci nodejs build version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:7.10
+      - image: circleci/node:12.19-buster
     working_directory: ~/onedrive-api
 
     steps:
@@ -25,7 +25,7 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-        
+
       # run tests!
       - run: npm test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking
 
-- Only support NodeJS version `4.x` or greater.
+- Only support NodeJS version `10.x` or greater.
 - All APIs are now implement with `promise`/`async` except `download()` API - it returns a `ReadableStream`. Other APIs should be used with `async/await`.
 - `delete()` API now return `boolean` value instead. `true` for deleting successfully.
 - Failure requests now should be handled with `try/catch`.


### PR DESCRIPTION
Bumping NodeJS version in CircleCI to support destructuring operator