### PR TITLE
Fix/handle o data special charachters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1]
+
+- Handle OData special charachters in the filename `'` and `(`
+
 ## [1.0.0]
 
 - Migrate to `got` since `request` [was deprecated](https://github.com/request/request/issues/3142). See more reason on this migration [here](https://github.com/dkatavic/onedrive-api/issues/30).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![CircleCI](https://circleci.com/gh/dkatavic/onedrive-api/tree/master.svg?style=svg&circle-token=0410ac864820f55930f276a46fa955a788b03eee)](https://circleci.com/gh/dkatavic/onedrive-api/tree/master)
 
-OneDrive API module for Node.js. It's built with pure functional programing, there are no unnecessary objects.
+OneDrive API module for NodeJS. This module handels operations with OneDrive API. For authenticating with OneDrive, we suggest using OS solutions like [simple-oauth2](https://github.com/lelylan/simple-oauth2). We are accepting pull requests for any missing features
 
-It's built for internal project so it supports only basic CRUD operations needed for project (for now). I will accept any pull requests.
 
 # Install
 
@@ -33,7 +32,7 @@ npm install onedrive-api
 ### Require module
 
 ```javascript
-var oneDriveAPI = require('onedrive-api');
+const oneDriveAPI = require('onedrive-api');
 ```
 
 ```javascript
@@ -121,7 +120,7 @@ Download item content
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 ```javascript
-var fileStream = oneDriveAPI.items.download({
+const fileStream = oneDriveAPI.items.download({
   accessToken: accessToken,
   itemId: createdFolder.id
 });
@@ -130,7 +129,7 @@ fileStream.pipe(SomeWritableStream);
 
 ### items.partialDownload
 
-Download item content partially. You must either provide `graphDownloadURL` or the `itemId` to download the file. 
+Download item content partially. You must either provide `graphDownloadURL` or the `itemId` to download the file.
 
 If only the `itemId` is provided, the function will try to get the download URL for you with additional `getMetadata()` function call.
 
@@ -149,7 +148,7 @@ If only the `itemId` is provided, the function will try to get the download URL 
 | params.driveId | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set. |
 
 ```javascript
-var partialPromise = oneDriveAPI.items.partialDownload({
+const partialPromise = oneDriveAPI.items.partialDownload({
   accessToken: accessToken,
   bytesFrom: 0, // start byte
   bytesTo: 1034, // to byte

--- a/lib/items/uploadSimple.js
+++ b/lib/items/uploadSimple.js
@@ -31,9 +31,12 @@ async function uploadSimple(params) {
     throw new Error("Missing params.readableStream");
   }
 
+  // Workaround for a "'"  in a filename OData issue https://github.com/OneDrive/onedrive-api-docs/issues/565
+  params.filename = params.filename.replace("'", "''")
+
   params.parentId = params.parentId === undefined ? "root" : params.parentId;
   const userPath = userPathGenerator(params);
-  let uri = appConfig.apiUrl + userPath + "items/" + params.parentId + "/children/" + params.filename + "/content";
+  let uri = appConfig.apiUrl + userPath + "items/" + params.parentId + "/children('" + params.filename + "')/content";
   if (params.parentPath !== undefined && typeof params.parentPath === "string") {
     uri = appConfig.apiUrl + userPath + "root:/" + path.join(params.parentPath, params.filename) + ":/content";
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "onedrive-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onedrive-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OneDrive module for communicating with oneDrive API. Built using functional programming pattern",
   "main": "lib/index.js",
   "scripts": {

--- a/test/e2e/items/uploadSimple.test.js
+++ b/test/e2e/items/uploadSimple.test.js
@@ -92,7 +92,7 @@ describe("uploadSimple", function () {
 });
 
 
-describe.only("uploadSimple Handle special characters", function () {
+describe("uploadSimple Handle special characters", function () {
   let filename, readableStream, fileContent, createdFile;
 
   beforeEach(() => {

--- a/test/e2e/items/uploadSimple.test.js
+++ b/test/e2e/items/uploadSimple.test.js
@@ -90,3 +90,64 @@ describe("uploadSimple", function () {
       .catch(errorHandler(done));
   });
 });
+
+
+describe.only("uploadSimple Handle special characters", function () {
+  let filename, readableStream, fileContent, createdFile;
+
+  beforeEach(() => {
+    filename = "test-uploadSimple-" + faker.random.word();
+    fileContent = faker.lorem.paragraphs();
+    readableStream = stringStream(fileContent);
+  });
+
+  afterEach(function (done) {
+    oneDrive.items
+      .delete({
+        accessToken: accessToken,
+        itemId: createdFile.id,
+      })
+      .then(() => done())
+      .catch(errorHandler(done));
+  });
+
+  it("Should handle special OData '(' charachter", function (done) {
+    filename = filename + 'testing(1).ico';
+    oneDrive.items
+      .uploadSimple({
+        accessToken: accessToken,
+        filename: filename,
+        readableStream: readableStream,
+      })
+      .then(function (item) {
+        expect(item.id).to.be.a("String");
+        expect(item.name).to.be.a("String");
+        expect(item.size).to.be.a("Number");
+        expect(item.size).to.be.at.least(1);
+        expect(item.id).to.be.a("String");
+        createdFile = item;
+        done();
+      })
+      .catch(errorHandler(done));
+  });
+
+  it("Should special OData ' charachter", function (done) {
+    filename = filename + "test'ing.ico";
+    oneDrive.items
+      .uploadSimple({
+        accessToken: accessToken,
+        filename: filename,
+        readableStream: readableStream,
+      })
+      .then(function (item) {
+        expect(item.id).to.be.a("String");
+        expect(item.name).to.be.a("String");
+        expect(item.size).to.be.a("Number");
+        expect(item.size).to.be.at.least(1);
+        expect(item.id).to.be.a("String");
+        createdFile = item;
+        done();
+      })
+      .catch(errorHandler(done));
+  });
+});


### PR DESCRIPTION
Handles OData special characters `(` and `'`.  Closes https://github.com/dkatavic/onedrive-api/issues/37

* Handles `(` by passing filename as function argument
* Handles `'` by replacing it with `''`