### PR TITLE
Use node 14 for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12.19-buster
+      - image: circleci/node:14-buster
     working_directory: ~/onedrive-api
 
     steps:
@@ -27,7 +27,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # Ensure Prettier + ESLint has been run on all JS files
-      - run: npx prettier "./**/*.{js}" && npx eslint "./**/*.{js}"
+      - run: npm run lint
 
       # run tests!
       - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "onedrive-api",
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "npm run test:unit",
     "test:e2e": "NODE_ENV=test mocha --config=./test/e2e/.mocharc.json ./test/e2e/bootstrap.test.js ./test/e2e/**/*.test.js",
     "test:unit": "NODE_ENV=test mocha  ./test/unit/*.test.js ./test/unit/**/*.test.js ",
+    "lint": "NODE_ENV=test npx eslint ./**/*.js",
     "release:tag": "git tag $npm_package_version && git push --tags"
   },
   "keywords": [


### PR DESCRIPTION
eslint is breaking on Node12 because of ESM. Changing build to Node14