### PR TITLE
Fixed authorization problems with download and partialDownload

### DIFF
--- a/lib/helpers/gotHelper.js
+++ b/lib/helpers/gotHelper.js
@@ -1,7 +1,7 @@
 const beforeRequestHookGot = (accessToken) => [
   (options) => {
     if (accessToken) {
-      options.headers.Authorization = accessToken;
+      options.headers.Authorization = "Bearer " + accessToken;
     }
   },
 ];


### PR DESCRIPTION
When requesting the content of a OneDrive file (download, partialDownload) with the Graph API the authorization failed (401 HTTP Error).
By adding the keyword "Bearer" in die Authentication header, the Access Token is accepted.

#59