### PR TITLE
Adding feature: Download a file in another format

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,13 @@ Download item content
 **Returns**: <code>ReadableStream</code> - Readable stream with item's content
 
 | Param              | Type                | Default     | Description                                                                                     |
-| ------------------ | ------------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+|--------------------| ------------------- | ----------- |-------------------------------------------------------------------------------------------------|
 | params             | <code>Object</code> |             |                                                                                                 |
 | params.accessToken | <code>String</code> |             | OneDrive access token                                                                           |
 | params.itemId      | <code>String</code> |             | item id                                                                                         |
 | params.drive       | <code>String</code> | `'me'`      | If it's set to be either `'user'`/`'drive'`/`'group'`/`'site'`, `params.driveId` has to be set. |
 | params.driveId     | <code>String</code> | `undefined` | The id of the drive that was shared to you. Must be set if `params.drive` is set.               |
+| params.format      | <code>String</code> | `undefined` | Converts the content to specified format. Format options: `'glb'`/`'html'`/`'jpg'`/`'pdf'`      |
 
 ```javascript
 const fileStream = oneDriveAPI.items.download({

--- a/lib/items/download.js
+++ b/lib/items/download.js
@@ -10,6 +10,7 @@ const gotConfig = require("../helpers/gotHelper");
  * @param {Object} params
  * @param {String} params.accessToken OneDrive access token
  * @param {String} params.itemId item id
+ * @param {String} params.format converts item to specified format
  *
  * @return {ReadableStream} Readable stream with item's content
  */
@@ -23,7 +24,7 @@ function download(params) {
   }
 
   const userPath = userPathGenerator(params);
-  const URI = appConfig.apiUrl + userPath + "items/" + params.itemId + "/content";
+  const URI = appConfig.apiUrl + userPath + "items/" + params.itemId + "/content" + (params.format ? `?format=${params.format}` : "");
 
   const gotExtend = got.extend({
     hooks: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onedrive-api",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "OneDrive module for communicating with oneDrive API. Built using functional programming pattern",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Enables retrieving the contents of an item in a specified format. Supported format options are listed in the MS Docs.

**From:**
[Microsoft OneDrive API Docs](https://learn.microsoft.com/en-gb/onedrive/developer/rest-api/api/driveitem_get_content_format?view=odsp-graph-online)