### PR TITLE
Set throwHttpErrors to false in uploadSession

### DIFF
--- a/lib/items/uploadSession.js
+++ b/lib/items/uploadSession.js
@@ -67,8 +67,9 @@ async function uploadSession(params, progress = () => {}) {
     headers: gotConfig.headerJSON,
     responseType: gotConfig.responseJSON,
     method: "POST",
+    throwHttpErrors: false,
   });
-  
+
   if(!(["rename", "fail", "replace"].includes(params.conflictBehavior)))
     params.conflictBehavior =  "rename";
 
@@ -104,6 +105,7 @@ async function uploadSession(params, progress = () => {}) {
               "bytes " + uploadedBytes + "-" + (uploadedBytes + chunksToUploadSize - 1) + "/" + params.fileSize,
           },
           body: payload,
+          throwHttpErrors: false,
         });
 
         uploadResponse = await uploadGotExtended(urlResponse.body.uploadUrl);


### PR DESCRIPTION
`uploadSession()` attempts to check the HTTP status code of `got` responses, but by default, `got` sets the `throwHttpErrors` parameter to `true`, meaning that the promises reject rather than return objects with ≥400 status codes. This causes the upload to leak unhandled promise rejections rather than report errors properly.