### PR TITLE
Update return type of download in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ oneDriveAPI.items
 
 Download item content
 
-**Returns**: <code>ReadableStream</code> - Readable stream with item's content
+**Returns**: <code>Promise<ReadableStream></code> - A promise with the result being a `Readable stream` with item's content
 
 | Param              | Type                | Default     | Description                                                                                     |
 |--------------------| ------------------- | ----------- |-------------------------------------------------------------------------------------------------|
@@ -123,11 +123,11 @@ Download item content
 | params.format      | <code>String</code> | `undefined` | Converts the content to specified format. Format options: `'glb'`/`'html'`/`'jpg'`/`'pdf'`      |
 
 ```javascript
-const fileStream = oneDriveAPI.items.download({
+const promise = oneDriveAPI.items.download({
   accessToken: accessToken,
   itemId: createdFolder.id,
 });
-fileStream.pipe(SomeWritableStream);
+promise.then((fileStream) => fileStream.pipe(SomeWritableStream));
 ```
 
 ### items.partialDownload

--- a/lib/items/download.js
+++ b/lib/items/download.js
@@ -12,7 +12,7 @@ const gotConfig = require("../helpers/gotHelper");
  * @param {String} params.itemId item id
  * @param {String} params.format converts item to specified format
  *
- * @return {ReadableStream} Readable stream with item's content
+ * @return {Promise<ReadableStream>} A promise with the result being a `Readable stream` with item's content
  */
 async function download(params) {
   if (!params.accessToken) {


### PR DESCRIPTION
As the return type of the `download` function changed from  `ReadableStream` to `Promise<ReadableStream>` in #71 , the documentation should be adjusted.