### PR TITLE
Fix: microsoft-graph-types as deps not devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/microsoft-graph-types": "^2.35.0",
         "got": "12.6.0",
         "is-empty-object": "1.1.1"
       },
       "devDependencies": {
-        "@microsoft/microsoft-graph-types": "^2.35.0",
         "@types/node": "^20.4.2",
         "chai": "4.2.0",
         "eslint": "^8.5.0",
@@ -118,8 +118,7 @@
     "node_modules/@microsoft/microsoft-graph-types": {
       "version": "2.35.0",
       "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.35.0.tgz",
-      "integrity": "sha512-3jCQyKaYbNuzVG884SNuWKS19FPUxBwHfDAb3DqZWBwPYcX3HbDe2D22z9Ue+UV+JGuw917cH75RTSgrdnutFg==",
-      "dev": true
+      "integrity": "sha512-3jCQyKaYbNuzVG884SNuWKS19FPUxBwHfDAb3DqZWBwPYcX3HbDe2D22z9Ue+UV+JGuw917cH75RTSgrdnutFg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2175,8 +2174,7 @@
     "@microsoft/microsoft-graph-types": {
       "version": "2.35.0",
       "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-types/-/microsoft-graph-types-2.35.0.tgz",
-      "integrity": "sha512-3jCQyKaYbNuzVG884SNuWKS19FPUxBwHfDAb3DqZWBwPYcX3HbDe2D22z9Ue+UV+JGuw917cH75RTSgrdnutFg==",
-      "dev": true
+      "integrity": "sha512-3jCQyKaYbNuzVG884SNuWKS19FPUxBwHfDAb3DqZWBwPYcX3HbDe2D22z9Ue+UV+JGuw917cH75RTSgrdnutFg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onedrive-api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "onedrive-api",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@microsoft/microsoft-graph-types": "^2.35.0",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "license": "MIT",
   "dependencies": {
     "got": "12.6.0",
-    "is-empty-object": "1.1.1"
+    "is-empty-object": "1.1.1",
+    "@microsoft/microsoft-graph-types": "^2.35.0"
   },
   "devDependencies": {
-    "@microsoft/microsoft-graph-types": "^2.35.0",
     "@types/node": "^20.4.2",
     "chai": "4.2.0",
     "eslint": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onedrive-api",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "OneDrive module for communicating with oneDrive API. Built using functional programming pattern",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
The `@microsoft/microsoft-graph-types` package needs to be provided as a dependency (not a devDependency) as the types are needed if the onedrive-api module is installed.

Follow-up for #77 

@namdien177 